### PR TITLE
I've disabled the scheduled GitHub Action tests.

### DIFF
--- a/.github/workflows/test-replication.yml
+++ b/.github/workflows/test-replication.yml
@@ -5,9 +5,9 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
-  schedule:
-    # Run tests daily at 2 AM UTC
-    - cron: '0 2 * * *'
+  # schedule:
+  #   # Run tests daily at 2 AM UTC
+  #   - cron: '0 2 * * *'
 
 env:
   DOCKER_HOST: unix:///var/run/docker.sock


### PR DESCRIPTION
I commented out the 'schedule' trigger in the .github/workflows/test-replication.yml file. This will temporarily disable the daily execution of the PostgreSQL logical replication tests.